### PR TITLE
Fix comp reg link and Contact button text

### DIFF
--- a/buzzbrewclub/templates/dashboard/landing.html
+++ b/buzzbrewclub/templates/dashboard/landing.html
@@ -101,7 +101,7 @@
             <div class="col">
               <h2>Annual Boneyard Brew Off</h2>
               <p>
-                Each year we host a homebrew competition. Go <a href="http://buzzbrewclub.org/competition">here</a> to learn the dates, to enter, and to see the winners.
+                Each year we host a homebrew competition. Go <a href="https://beerawardsplatform.com/buzz-brewoff-2023">here</a> to learn the dates, to enter, and to see the winners.
               </p>
             </div>
           </div>

--- a/buzzbrewclub/templates/includes/navbar.html
+++ b/buzzbrewclub/templates/includes/navbar.html
@@ -34,7 +34,7 @@
         </li>
       {% endif %}
       <li class="nav-item">
-        <a class="nav-link" href="mailto:beer@buzzbrew.club">Contact</a>
+        <a class="nav-link" href="mailto:beer@buzzbrew.club">Contact B.U.Z.Z.</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" target="_blank" href="https://www.facebook.com/groups/buzzbrewclub">Facebook</a>


### PR DESCRIPTION
Tim, I made two changes to the current buzz brew.club page
1. Updated competition link to point at https://beerawardsplatform.com/buzz-brewoff-2023
2. Updated the Contact button on the home page to say "Contact B.U.Z.Z."

Can you please review these changes? I've tested locally and they seem to work. Anything else needed to test before pushing to production server?